### PR TITLE
Removing animation and running end scene with coroutine

### DIFF
--- a/Assets/Scenes/00-Intro.unity
+++ b/Assets/Scenes/00-Intro.unity
@@ -621,7 +621,7 @@ Animator:
   m_GameObject: {fileID: 468240825}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 8a93cdd498f67431e8ee843f6c0e15a1, type: 2}
+  m_Controller: {fileID: 0}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -1504,6 +1504,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7302452808054371354, guid: dc52135453fe1405d952fd87e3d9833a,
         type: 3}
+      propertyPath: m_Positions.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7302452808054371354, guid: dc52135453fe1405d952fd87e3d9833a,
+        type: 3}
       propertyPath: m_Parameters.colorGradient.ctime1
       value: 65535
       objectReference: {fileID: 0}
@@ -1541,6 +1546,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Parameters.colorGradient.ctime0
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7302452808054371354, guid: dc52135453fe1405d952fd87e3d9833a,
+        type: 3}
+      propertyPath: m_Positions.Array.data[2].x
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 7302452808054371355, guid: dc52135453fe1405d952fd87e3d9833a,
         type: 3}

--- a/Assets/Scenes/00-Intro.unity
+++ b/Assets/Scenes/00-Intro.unity
@@ -554,6 +554,8 @@ MonoBehaviour:
   boxBlack: {fileID: 1459506382}
   whiteText: {fileID: 201317942}
   blackText: {fileID: 1897195037}
+  essayText: {fileID: 13675333}
+  ruppyText: {fileID: 301110120}
   wall01: {fileID: 1051206173}
   wall02: {fileID: 486378471}
   currentStep: 0

--- a/Assets/Scripts/IntroScene.cs
+++ b/Assets/Scripts/IntroScene.cs
@@ -58,7 +58,8 @@ public class IntroScene : MonoBehaviour {
         disableScene(currentStep-1);
 
         if (currentStep == 4) {
-            animator.SetTrigger("animateEnd");
+            //animator.SetTrigger("animateEnd");
+            laserWhite.GetComponent<LaserController>().FadeOut();
         }
     }
 

--- a/Assets/Scripts/IntroScene.cs
+++ b/Assets/Scripts/IntroScene.cs
@@ -14,6 +14,8 @@ public class IntroScene : MonoBehaviour {
     public GameObject boxBlack;
     public Text whiteText;
     public Text blackText;
+    public Text essayText;
+    public Text ruppyText;
     public GameObject wall01;
     public GameObject wall02;
 
@@ -59,8 +61,17 @@ public class IntroScene : MonoBehaviour {
 
         if (currentStep == 4) {
             laserWhite.GetComponent<LaserController>().FadeOut();
-            StartCoroutine("FadeTextOut");
+            textAnimations();
         }
+    }
+
+    public void textAnimations() {
+        Color whiteColor = Color.white;
+        Color blackColor = Color.black;
+        IEnumerator fadeInRuppyText = AnimateText(ruppyText, blackColor, whiteColor, 0, 5, null);
+        IEnumerator fadeInEssayText = AnimateText(essayText, blackColor, whiteColor, 0, 5, fadeInRuppyText);
+        IEnumerator fadeOutWhiteText = AnimateText(whiteText, whiteColor, blackColor, 5, 10, fadeInEssayText);
+        StartCoroutine(fadeOutWhiteText);
     }
 
     public void WillIncreaseStep() {
@@ -81,17 +92,21 @@ public class IntroScene : MonoBehaviour {
         }
     }
 
-    IEnumerator FadeTextOut() {
-        Color colorToFade = Color.black;
+    IEnumerator AnimateText(Text text, Color startColor, Color endColor, float delay, float duration, IEnumerator onEnd) {
+        yield return new WaitForSeconds(delay);
+        text.gameObject.SetActive(true);
         float progress = 0;
-        float smoothness = 0.2f;
-        float duration = 10;
+        float smoothness = 0.1f;
         float increment = smoothness / duration;
         while (progress < 1) {
             progress += increment;
-            Color newColor = Color.Lerp(whiteText.color, colorToFade, progress);
-            whiteText.color = newColor;
+            Color newColor = Color.Lerp(startColor, endColor, progress);
+            text.color = newColor;
             yield return new WaitForSeconds(smoothness);
+        }
+
+        if (onEnd != null) {
+            StartCoroutine(onEnd);
         }
     }
 

--- a/Assets/Scripts/IntroScene.cs
+++ b/Assets/Scripts/IntroScene.cs
@@ -58,7 +58,6 @@ public class IntroScene : MonoBehaviour {
         disableScene(currentStep-1);
 
         if (currentStep == 4) {
-            //animator.SetTrigger("animateEnd");
             laserWhite.GetComponent<LaserController>().FadeOut();
         }
     }

--- a/Assets/Scripts/IntroScene.cs
+++ b/Assets/Scripts/IntroScene.cs
@@ -59,6 +59,7 @@ public class IntroScene : MonoBehaviour {
 
         if (currentStep == 4) {
             laserWhite.GetComponent<LaserController>().FadeOut();
+            StartCoroutine("FadeTextOut");
         }
     }
 
@@ -77,6 +78,20 @@ public class IntroScene : MonoBehaviour {
             mirrorBlack.transform.position = new Vector3(7.36f, -0.29f, 0f);
         } else if (nextStep == 4) {
             whiteText.text = "and almost impossible to get out of it";
+        }
+    }
+
+    IEnumerator FadeTextOut() {
+        Color colorToFade = Color.black;
+        float progress = 0;
+        float smoothness = 0.2f;
+        float duration = 10;
+        float increment = smoothness / duration;
+        while (progress < 1) {
+            progress += increment;
+            Color newColor = Color.Lerp(whiteText.color, colorToFade, progress);
+            whiteText.color = newColor;
+            yield return new WaitForSeconds(smoothness);
         }
     }
 

--- a/Assets/Scripts/LaserController.cs
+++ b/Assets/Scripts/LaserController.cs
@@ -22,7 +22,7 @@ public class LaserController : MonoBehaviour
     }
 
     public void OnEnable() {
-        //Debug.Log("Im being enable " + hitIdentifier);
+        Debug.Log("Im being enable " + hitIdentifier + " " + GetComponent<LineRenderer>().startWidth);
     }
 
 
@@ -36,6 +36,22 @@ public class LaserController : MonoBehaviour
         else {
           //line.enabled = false;
         }
+    }
+
+    public void FadeOut() {
+        StartCoroutine("FadeWidthOut");
+    }
+
+    IEnumerator FadeWidthOut() { 
+        float smoothness = 0.1f;
+        float width = GetComponent<LineRenderer>().startWidth;
+        while (width > 0.005f) {
+            GetComponent<LineRenderer>().startWidth = width * 0.95f;
+            width = GetComponent<LineRenderer>().startWidth;
+            Debug.Log("tamo diminuindo");
+            yield return new WaitForSeconds(smoothness);
+        }
+        GetComponent<LineRenderer>().startWidth = 0;
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/LaserController.cs
+++ b/Assets/Scripts/LaserController.cs
@@ -22,7 +22,7 @@ public class LaserController : MonoBehaviour
     }
 
     public void OnEnable() {
-        Debug.Log("Im being enable " + hitIdentifier + " " + GetComponent<LineRenderer>().startWidth);
+        //Debug.Log("Im being enable " + hitIdentifier);
     }
 
 

--- a/Assets/Scripts/LaserController.cs
+++ b/Assets/Scripts/LaserController.cs
@@ -25,7 +25,6 @@ public class LaserController : MonoBehaviour
         //Debug.Log("Im being enable " + hitIdentifier);
     }
 
-
     // Start is called before the first frame update
     void Start()
     {
@@ -42,13 +41,12 @@ public class LaserController : MonoBehaviour
         StartCoroutine("FadeWidthOut");
     }
 
-    IEnumerator FadeWidthOut() { 
+    IEnumerator FadeWidthOut() {
         float smoothness = 0.1f;
         float width = GetComponent<LineRenderer>().startWidth;
         while (width > 0.005f) {
-            GetComponent<LineRenderer>().startWidth = width * 0.95f;
+            GetComponent<LineRenderer>().startWidth = width * 0.97f;
             width = GetComponent<LineRenderer>().startWidth;
-            Debug.Log("tamo diminuindo");
             yield return new WaitForSeconds(smoothness);
         }
         GetComponent<LineRenderer>().startWidth = 0;


### PR DESCRIPTION
Fix #2 

White laser was used in the "Puzzle" animation, therefore the engine tried to keep it active at all times. Confirmed through removing the animation from scene.

Solved by making the final transition with a coroutine in LaserController.

It's worth checking if the final solution looks better than using the animation. 